### PR TITLE
Provided minibatch weighting

### DIFF
--- a/blitz/utils/minibatch_weighting.py
+++ b/blitz/utils/minibatch_weighting.py
@@ -1,0 +1,16 @@
+def minibatch_weight(batch_idx, num_batches):
+
+    """Calculates the minibatch weight.
+
+        A formula for calculating the minibatch weight is described in
+        section 3.4 of the 'Weight Uncertainty in Neural Networks' paper.
+        The weighting decreases as the batch index increases, this is
+        because the the first few batches are influenced heavily by
+        the complexity cost.
+
+    Parameters:
+        batch_idx: int -> the current batch index
+        num_batches: int -> the total number of batches
+    """
+
+    return 2 ^ (num_batches - batch_idx) / (2 ^ num_batches - batch_idx)


### PR DESCRIPTION
Provided an implementation of minibatch weighting as described in section 3.4 of the [Weight Uncertainty in Neural Networks](https://arxiv.org/pdf/1505.05424.pdf) paper.

Resolves: #11