### PR TITLE
fix: .normal_() on self.eps_weight.data

### DIFF
--- a/blitz/modules/weight_sampler.py
+++ b/blitz/modules/weight_sampler.py
@@ -28,7 +28,7 @@ class GaussianVariational(nn.Module):
             torch.tensor with same shape as self.mu and self.rho
         """
 
-        self.eps_w.normal_()
+        self.eps_w.data.normal_()
         self.sigma = torch.log1p(torch.exp(self.rho))
         self.w = self.mu + self.sigma * self.eps_w
         return self.w


### PR DESCRIPTION
Now it works with siamese architectures and when we need to double feedforward before gathering loss and backpropagating.