### PR TITLE
Fix mean in sample_elbo

### DIFF
--- a/blitz/utils/variational_estimator.py
+++ b/blitz/utils/variational_estimator.py
@@ -63,7 +63,7 @@ def variational_estimator(nn_class):
         loss = 0
         for _ in range(sample_nbr):
             outputs = self(inputs)
-            loss = criterion(outputs, labels) 
+            loss += criterion(outputs, labels) 
             loss += self.nn_kl_divergence() * complexity_cost_weight
         return loss / sample_nbr
     


### PR DESCRIPTION
Hi,

should not this line be 
"            loss += criterion(outputs, labels) "
?

https://github.com/piEsposito/blitz-bayesian-deep-learning/blob/fd5fdfa1912e24d1733ee7ad0b78d223e0e12b50/blitz/utils/variational_estimator.py#L66