### PR TITLE
Fix: bayesian regression example

### DIFF
--- a/blitz/examples/bayesian_regression_boston.py
+++ b/blitz/examples/bayesian_regression_boston.py
@@ -35,6 +35,7 @@ class BayesianRegressor(nn.Module):
         
     def forward(self, x):
         x_ = self.blinear1(x)
+        x_ = F.relu(x_)
         return self.blinear2(x_)
 
 


### PR DESCRIPTION
Without activation network doesn't converge and loss is all over the place.