### PR TITLE
Make the boston example converge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ class BayesianRegressor(nn.Module):
         
     def forward(self, x):
         x_ = self.blinear1(x)
+        x_ = F.relu(x_)
         return self.blinear2(x_)
 ```
 
@@ -154,7 +155,7 @@ Notice here that we create our `BayesianRegressor` as we would do with other neu
 
 ```python
 regressor = BayesianRegressor(13, 1)
-optimizer = optim.SGD(regressor.parameters(), lr=0.001)
+optimizer = optim.Adam(regressor.parameters(), lr=0.01)
 criterion = torch.nn.MSELoss()
 
 ds_train = torch.utils.data.TensorDataset(X_train, y_train)


### PR DESCRIPTION
The code for the boston regression example in readme doesn't converge. It seems to differ from `blitz/examples/bayesian_regression_boston.py' a little bit. I changed an optimizer and added the activation function to match the code from examples and now the readme version converges as well.

There are other differences, like a number of epochs (100 vs 1000), cuda usage, and the `complexity_cost_weight` argument in elbo, but as the readme started to converge anyway, I've left out these changes to keep it simple.