### PR TITLE
Interface features both parts of the ELBO-loss (likelihood part and performance part)

### DIFF
--- a/blitz/utils/variational_estimator.py
+++ b/blitz/utils/variational_estimator.py
@@ -75,7 +75,7 @@ def variational_estimator(nn_class):
                     complexity_cost_weight=1):
 
         """ Samples the ELBO Loss for a batch of data, consisting of inputs and corresponding-by-index labels.
-            This version of the function returns the performance part and complexity part of the Loss individually
+            This version of the function returns the performance part and complexity part of the loss individually
             as well as an array of predictions
 
                 The ELBO Loss consists of the sum of the KL Divergence of the model 

--- a/blitz/utils/variational_estimator.py
+++ b/blitz/utils/variational_estimator.py
@@ -41,6 +41,42 @@ def variational_estimator(nn_class):
                     complexity_cost_weight=1):
 
         """ Samples the ELBO Loss for a batch of data, consisting of inputs and corresponding-by-index labels
+                The ELBO Loss consists of the sum of the KL Divergence of the model
+                 (explained above, interpreted as a "complexity part" of the loss)
+                 with the actual criterion - (loss function) of optimization of our model
+                 (the performance part of the loss).
+                As we are using variational inference, it takes several (quantified by the parameter sample_nbr) Monte-Carlo
+                 samples of the weights in order to gather a better approximation for the loss.
+            Parameters:
+                inputs: torch.tensor -> the input data to the model
+                labels: torch.tensor -> label data for the performance-part of the loss calculation
+                        The shape of the labels must match the label-parameter shape of the criterion (one hot encoded or as index, if needed)
+                criterion: torch.nn.Module, custom criterion (loss) function, torch.nn.functional function -> criterion to gather
+                            the performance cost for the model
+                sample_nbr: int -> The number of times of the weight-sampling and predictions done in our Monte-Carlo approach to
+                            gather the loss to be .backwarded in the optimization of the model.
+
+        """
+
+        loss = 0
+        for _ in range(sample_nbr):
+            outputs = self(inputs)
+            loss += criterion(outputs, labels)
+            loss += self.nn_kl_divergence() * complexity_cost_weight
+        return loss / sample_nbr
+
+    setattr(nn_class, "sample_elbo", sample_elbo)
+
+    def sample_elbo_detailed_loss(self,
+                    inputs,
+                    labels,
+                    criterion,
+                    sample_nbr,
+                    complexity_cost_weight=1):
+
+        """ Samples the ELBO Loss for a batch of data, consisting of inputs and corresponding-by-index labels.
+            This version of the function returns the performance part and complexity part of the Loss individually
+            as well as an array of predictions
 
                 The ELBO Loss consists of the sum of the KL Divergence of the model 
                  (explained above, interpreted as a "complexity part" of the loss)
@@ -58,8 +94,7 @@ def variational_estimator(nn_class):
                             the performance cost for the model
                 sample_nbr: int -> The number of times of the weight-sampling and predictions done in our Monte-Carlo approach to 
                             gather the loss to be .backwarded in the optimization of the model.
-
-            Outputs:
+            Returns:
                 array of predictions
                 ELBO Loss
                 performance part
@@ -81,7 +116,7 @@ def variational_estimator(nn_class):
                likelihood_cost / sample_nbr,\
                complexity_cost / sample_nbr
     
-    setattr(nn_class, "sample_elbo", sample_elbo)
+    setattr(nn_class, "sample_elbo_detailed_loss", sample_elbo)
 
 
     def freeze_model(self):

--- a/blitz/utils/variational_estimator.py
+++ b/blitz/utils/variational_estimator.py
@@ -118,7 +118,6 @@ def variational_estimator(nn_class):
     
     setattr(nn_class, "sample_elbo_detailed_loss", sample_elbo_detailed_loss)
 
-
     def freeze_model(self):
         """
         Freezes the model by making it predict using only the expected value to their BayesianModules' weights distributions

--- a/blitz/utils/variational_estimator.py
+++ b/blitz/utils/variational_estimator.py
@@ -116,7 +116,7 @@ def variational_estimator(nn_class):
                likelihood_cost / sample_nbr,\
                complexity_cost / sample_nbr
     
-    setattr(nn_class, "sample_elbo_detailed_loss", sample_elbo)
+    setattr(nn_class, "sample_elbo_detailed_loss", sample_elbo_detailed_loss)
 
 
     def freeze_model(self):

--- a/blitz/utils/variational_estimator.py
+++ b/blitz/utils/variational_estimator.py
@@ -45,7 +45,7 @@ def variational_estimator(nn_class):
                 The ELBO Loss consists of the sum of the KL Divergence of the model 
                  (explained above, interpreted as a "complexity part" of the loss)
                  with the actual criterion - (loss function) of optimization of our model
-                 (the performance part of the loss). 
+                 (the performance part of the loss).
 
                 As we are using variational inference, it takes several (quantified by the parameter sample_nbr) Monte-Carlo
                  samples of the weights in order to gather a better approximation for the loss.
@@ -57,7 +57,13 @@ def variational_estimator(nn_class):
                 criterion: torch.nn.Module, custom criterion (loss) function, torch.nn.functional function -> criterion to gather
                             the performance cost for the model
                 sample_nbr: int -> The number of times of the weight-sampling and predictions done in our Monte-Carlo approach to 
-                            gather the loss to be .backwarded in the optimization of the model.        
+                            gather the loss to be .backwarded in the optimization of the model.
+
+            Outputs:
+                array of predictions
+                ELBO Loss
+                performance part
+                complexity part
         
         """
 


### PR DESCRIPTION
For my recent work about Bayesian Neural Networks for Time Series Forecasting in Hydrology I needed a slight modification of the BLiTZ-library where the function _sample_elbo_ in _variational_estimator.py_ does not only output the total loss, but the likelihood part and performance part individually. In addition, my version outputs the model predictions.

As I think that this could be sensible addition for public use of the library, I would like to apply for a change here.

Best regards,
Jonas Fill