### PR TITLE
bugfix - zeroed bias need to inherit device

### DIFF
--- a/blitz/modules/linear_bayesian_layer.py
+++ b/blitz/modules/linear_bayesian_layer.py
@@ -84,7 +84,7 @@ class BayesianLinear(BayesianModule):
             b_log_prior = self.bias_prior_dist.log_prior(b)
 
         else:
-            b = torch.zeros((self.out_features))
+            b = torch.zeros((self.out_features), device=x.device)
             b_log_posterior = 0
             b_log_prior = 0
 


### PR DESCRIPTION
Addresses #109 

n.b. I don't think `Object` classes inherit a `self.device` attribute? So I've set the zero tensor to acquire device from `x`.